### PR TITLE
Fix User32Api.GetTextFromWindow method

### DIFF
--- a/src/Dapplo.Windows.User32/User32Api.cs
+++ b/src/Dapplo.Windows.User32/User32Api.cs
@@ -229,7 +229,7 @@ namespace Dapplo.Windows.User32
             unsafe
             {
                 var text = stackalloc char[size + 1];
-                SendMessage(hWnd, WindowsMessages.WM_GETTEXT, size, text);
+                SendMessage(hWnd, WindowsMessages.WM_GETTEXT, size + 1, text);
                 return new string(text, 0, size);
             }
         }


### PR DESCRIPTION
Last character in returned text was removed and null character was appended.